### PR TITLE
Fix deserialization of ValidatorId

### DIFF
--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -270,9 +270,18 @@ pub struct FinalityCheckpointsData {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "&str")]
 pub enum ValidatorId {
     PublicKey(PublicKeyBytes),
     Index(u64),
+}
+
+impl TryFrom<&str> for ValidatorId {
+    type Error = String;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Self::from_str(s)
+    }
 }
 
 impl FromStr for ValidatorId {


### PR DESCRIPTION
This fixes the deserialization of `ValidatorId`. The problem was that the `Deserialize` implementation wasn't using the clever auto-detection, which was only implemented in the `FromStr` logic. This shim makes it so that `Deserialize` does use the auto-detection.

CC @kevinbogner 
